### PR TITLE
make fsharp mode aot-capable

### DIFF
--- a/fsharp/fsharp.fsproj
+++ b/fsharp/fsharp.fsproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
+    <!-- <PublishAOT>true</PublishAOT> -->
   </PropertyGroup>
 
   <ItemGroup>
@@ -10,6 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Chiron" Version="7.0.0-beta-180105" />
     <PackageReference Include="FSharp.Json" Version="0.4.1" />
   </ItemGroup>
 

--- a/fsharp_con/fsharp_con.fsproj
+++ b/fsharp_con/fsharp_con.fsproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
+    <JsonSerializerIsReflectionEnabledByDefault>true</JsonSerializerIsReflectionEnabledByDefault>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
When I AOT-publish this on Ubuntu WSL I get the following error:

```
./bin/Release/net8.0/linux-x64/publish/fsharp
Unhandled Exception: System.InvalidOperationException: TypeInfoResolver 'Program+Serialization+clo@158' did not provide property metadata for type 'Program+Post'.
   at System.Text.Json.ThrowHelper.ThrowInvalidOperationException_NoMetadataForTypeProperties(IJsonTypeInfoResolver, Type) + 0xe
   at System.Text.Json.JsonSerializer.LookupProperty(Object, ReadOnlySpan`1, ReadStack&, JsonSerializerOptions, Boolean&, Boolean) + 0x719
   at System.Text.Json.Serialization.Converters.ObjectDefaultConverter`1.OnTryRead(Utf8JsonReader&, Type, JsonSerializerOptions, ReadStack&, T&) + 0x8db
   at System.Text.Json.Serialization.JsonConverter`1.TryRead(Utf8JsonReader&, Type, JsonSerializerOptions, ReadStack&, T&, Boolean&) + 0x1a2
   at System.Text.Json.Serialization.JsonCollectionConverter`2.OnTryRead(Utf8JsonReader&, Type, JsonSerializerOptions, ReadStack&, TCollection&) + 0x502
   at System.Text.Json.Serialization.JsonConverter`1.TryRead(Utf8JsonReader&, Type, JsonSerializerOptions, ReadStack&, T&, Boolean&) + 0x235
   at System.Text.Json.Serialization.JsonConverter`1.ReadCore(Utf8JsonReader&, JsonSerializerOptions, ReadStack&) + 0x170
   at System.Text.Json.Serialization.Metadata.JsonTypeInfo`1.ContinueDeserialize(ReadBufferState&, JsonReaderState&, ReadStack&) + 0xf7
   at System.Text.Json.Serialization.Metadata.JsonTypeInfo`1.Deserialize(Stream) + 0x122
   at <StartupCode$fsharp>.$Program.main@() + 0x6e1
   at fsharp!<BaseAddress>+0x21a9d4
```

Suggesting I've messed up my registration somehow...despite setting up the required registrations (I think).